### PR TITLE
Bump Newtonsoft.Json from 9.0.1 to 13.0.3 in /src/ClassLibraryWithVersionOverride

### DIFF
--- a/src/ClassLibraryWithVersionOverride/ClassLibraryWithVersionOverride.csproj
+++ b/src/ClassLibraryWithVersionOverride/ClassLibraryWithVersionOverride.csproj
@@ -8,6 +8,6 @@
     <!--
       The centrally defined version of Newtonsoft.Json is 13.0.1 but this project wants to override that with version 9.0.1.
     -->
-    <PackageReference Include="Newtonsoft.Json" VersionOverride="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" VersionOverride="13.0.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Bumps Newtonsoft.Json from 9.0.1 to 13.0.3.
